### PR TITLE
chore(devcontainer): add `devcontainer`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:0-ubuntu-22.04
+
+RUN apt-get update \
+  && apt-get install -y \
+  libwebkit2gtk-4.1-dev \
+  build-essential \
+  curl \
+  wget \
+  file \
+  libxdo-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+{
+  "name": "tauri-dev",
+  // image size: 3.67GB
+  // build time: 862573 ms -> 14.375 mins
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "init": true,
+  "features": {
+    // http://localhost:6080
+    "ghcr.io/devcontainers/features/desktop-lite:1": {
+      "version": "latest",
+      "noVncVersion": "1.2.0",
+      "password": "vscode",
+      "webPort": "6080",
+      "vncPort": "5901"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.91",
+      "profile": "minimal"
+    }
+  },
+  "forwardPorts": [6080, 3000],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "belfz.search-crates-io",
+        "DavidAnson.vscode-markdownlint",
+        "eamodio.gitlens",
+        "EditorConfig.EditorConfig",
+        "emilast.LogFileHighlighter",
+        "fill-labs.dependi",
+        "github.vscode-github-actions",
+        "Gruntfuggly.todo-tree",
+        "mateuszchudyk.hexinspector",
+        "mhutchie.git-graph",
+        "ms-azuretools.vscode-docker",
+        "oderwat.indent-rainbow",
+        "redhat.vscode-yaml",
+        "rust-lang.rust-analyzer",
+        "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml",
+        "tauri-apps.tauri-vscode",
+        "vadimcn.vscode-lldb"
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.test.gui",
   "build": {
     "frontendDist": "../dist",
-    "devUrl": "http://localhost:3000",
+    "devUrl": "http://localhost:5173",
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build"
   },


### PR DESCRIPTION
Enable Hot Module Replacement (HMR) for `npm run tauri dev` using a Docker container with VNC.

How to use ref: https://pc.atsuhiro-me.net/entry/2023/04/12/040513

<img width="1258" height="875" alt="{81FC1DA6-A6A1-4AB4-86A1-388F431FFB14}" src="https://github.com/user-attachments/assets/4d50cb41-219f-4f57-a201-33917f546f55" />
